### PR TITLE
Add macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # AutoClick
+
+AutoClick provides a simple way to locate a template image inside a bigger screenshot and automate mouse actions. It includes a command line example and a small GUI for managing multiple templates.
+
+## Features
+
+- ORB based feature matching with a template fallback
+- Screenshot cropping interface for quickly creating templates
+- Global hotkey to trigger searches
+- Works on Windows, Linux and macOS
+
+## Requirements
+
+- Python 3.8+
+- `opencv-python-headless`
+- `numpy`
+- `Pillow`
+- `pyautogui`
+- `keyboard` (Windows/Linux)
+- `pynput` (macOS)
+- On macOS the packages `pyobjc-core` and `pyobjc` are required for screenshots
+
+Install the dependencies with:
+
+```bash
+pip install opencv-python-headless numpy Pillow pyautogui keyboard pynput pyobjc-core pyobjc
+```
+
+## Usage
+
+Run the test script to see the matcher in action:
+
+```bash
+python KeyleFinderModuleTest.py
+```
+
+Launch the GUI tool with:
+
+```bash
+python gui_locator_multi.py
+```
+
+Press the configured hotkey (default `F2`) to scan the screen for your templates.

--- a/gui_locator_multi.py
+++ b/gui_locator_multi.py
@@ -6,7 +6,35 @@ import os
 import json
 import base64
 import pyautogui
-import keyboard
+import sys
+
+try:
+    import keyboard as _keyboard
+except Exception:
+    _keyboard = None
+
+if sys.platform == 'darwin':
+    from pynput import keyboard as _pynput_keyboard
+
+    class _MacHotkey:
+        def __init__(self):
+            self._listener = None
+
+        def add_hotkey(self, key, callback):
+            if self._listener:
+                self._listener.stop()
+            hotkey = f'<{key.lower()}>'
+            self._listener = _pynput_keyboard.GlobalHotKeys({hotkey: callback})
+            self._listener.start()
+
+        def clear_all_hotkeys(self):
+            if self._listener:
+                self._listener.stop()
+                self._listener = None
+
+    keyboard = _MacHotkey()
+else:
+    keyboard = _keyboard
 import time
 
 from KeyleFinderModule import KeyleFinderModule


### PR DESCRIPTION
## Summary
- support global hotkeys on macOS using pynput
- improve documentation with install and usage instructions

## Testing
- `python KeyleFinderModuleTest.py` *(fails: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6841adc11004832397cbaba93bbf667e