### PR TITLE
Add CLI workflow tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,30 @@ python gui_locator_multi.py
 ```
 
 Press the configured hotkey (default `F2`) to scan the screen for your templates.
+
+## CLI Workflow Tool
+
+You can execute a sequence of template clicks directly from the command line using `cli_workflow.py`:
+
+```bash
+python cli_workflow.py workflow.json
+```
+
+`workflow.json` is compatible with files exported from the GUI. Each entry contains base64 encoded image data and an optional `double_click` flag.
+
+## 中文简介
+
+AutoClick 是一个自动点击工具，通过配置模板图像来实现开发者自动化工作流程。
+
+### 功能
+
+- 基于 ORB 的特征匹配，失败时回退到模板匹配
+- 方便的截图修剪界面用于创建模板
+- 全局热键触发搜索
+- 支持 Windows、Linux 和 macOS
+
+### 使用
+
+1. `python KeyleFinderModuleTest.py`运行测试
+2. `python gui_locator_multi.py`启动图形界面
+3. `python cli_workflow.py workflow.json`从命令行执行工作流程

--- a/cli_workflow.py
+++ b/cli_workflow.py
@@ -1,0 +1,79 @@
+import json
+import base64
+import tempfile
+import os
+import time
+import argparse
+from KeyleFinderModule import KeyleFinderModule
+
+
+def load_items(config_path):
+    with open(config_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    items = []
+    for entry in data:
+        if 'image' in entry:
+            img_data = base64.b64decode(entry['image'])
+            tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.png')
+            tmp.write(img_data)
+            tmp.close()
+            path = tmp.name
+        else:
+            path = entry['path']
+        items.append({'path': path, 'double_click': entry.get('double_click', False)})
+    return items
+
+
+def cleanup_items(items):
+    for item in items:
+        path = item['path']
+        if path.startswith(tempfile.gettempdir()) and os.path.exists(path):
+            os.unlink(path)
+
+
+def run_workflow(items, debug=False, loop=False, interval=0.5):
+    import pyautogui
+    try:
+        while True:
+            screenshot = pyautogui.screenshot()
+            with tempfile.NamedTemporaryFile(delete=False, suffix='.png') as tmp:
+                screenshot.save(tmp.name)
+                screen_path = tmp.name
+            finder = KeyleFinderModule(screen_path)
+            for idx, item in enumerate(items):
+                result = finder.locate(item['path'], debug=debug)
+                if result.get('status') == 0:
+                    tl = result['top_left']
+                    br = result['bottom_right']
+                    center_x = (tl[0] + br[0]) // 2
+                    center_y = (tl[1] + br[1]) // 2
+                    pyautogui.moveTo(center_x, center_y)
+                    if item['double_click']:
+                        pyautogui.click(clicks=2)
+                    else:
+                        pyautogui.click()
+                    print(f'Item {idx} matched at {center_x},{center_y}')
+                else:
+                    print(f'Item {idx} match failed')
+            os.unlink(screen_path)
+            if not loop:
+                break
+            time.sleep(interval)
+    finally:
+        cleanup_items(items)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run AutoClick workflow from a JSON file')
+    parser.add_argument('config', help='JSON workflow file exported from the GUI')
+    parser.add_argument('--debug', action='store_true', help='show debug preview windows')
+    parser.add_argument('--loop', action='store_true', help='repeat workflow until interrupted')
+    parser.add_argument('--interval', type=float, default=0.5, help='delay between loops in seconds')
+    args = parser.parse_args()
+
+    items = load_items(args.config)
+    run_workflow(items, debug=args.debug, loop=args.loop, interval=args.interval)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `cli_workflow.py` to run click sequences defined in a JSON workflow file
- document workflow CLI and add Chinese documentation

## Testing
- `pip install opencv-python-headless numpy Pillow pyautogui keyboard pynput`
- `python KeyleFinderModuleTest.py`
- `python cli_workflow.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6841b091de148323a24536726f97f408