### PR TITLE
Add fail-safe toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ AutoClick provides a simple way to locate a template image inside a bigger scree
 - ORB based feature matching with a template fallback
 - Screenshot cropping interface for quickly creating templates
 - Global hotkey to trigger searches
+- Optional PyAutoGUI fail-safe toggle
 - Works on Windows, Linux and macOS
 
 ## Requirements
@@ -48,6 +49,11 @@ Press the configured hotkey (default `F2`) to scan the screen for your templates
 Enable **Auto Start** in the settings window if you want the start button to run
 all items from top to bottom automatically. When unchecked, only the currently
 selected item is executed when you press start.
+
+The settings window also provides a **Fail-safe** option. When enabled (the
+default), moving the mouse to any screen corner aborts automation. You can
+disable this behavior by unchecking the box or passing `--disable-failsafe` to
+`cli_workflow.py`.
 
 ## CLI Workflow Tool
 

--- a/cli_workflow.py
+++ b/cli_workflow.py
@@ -102,7 +102,12 @@ def main():
     parser.add_argument('--debug', action='store_true', help='show debug preview windows')
     parser.add_argument('--loop', action='store_true', help='repeat workflow until interrupted')
     parser.add_argument('--interval', type=float, default=0.5, help='delay between loops in seconds')
+    parser.add_argument('--disable-failsafe', action='store_true',
+                        help='disable PyAutoGUI fail-safe (use with caution)')
     args = parser.parse_args()
+
+    if args.disable_failsafe:
+        pyautogui.FAILSAFE = False
 
     items = load_items(args.config)
     run_workflow(items, debug=args.debug, loop=args.loop, interval=args.interval)

--- a/gui_locator_multi.py
+++ b/gui_locator_multi.py
@@ -127,6 +127,7 @@ class App(tk.Tk):
         self.debug_var = tk.BooleanVar(value=False)
         self.auto_start_var = tk.BooleanVar(value=False)
         self.loop_var = tk.BooleanVar(value=False)
+        self.failsafe_var = tk.BooleanVar(value=True)
         self.hotkey_var = tk.StringVar(value=HOTKEY)
 
         top = ttk.Frame(self)
@@ -181,6 +182,8 @@ class App(tk.Tk):
         self.log_label.bind('<Button-1>', self.copy_log)
 
         self.hotkey_var.trace_add('write', self.update_hotkey)
+        self.failsafe_var.trace_add('write', self.update_failsafe)
+        self.update_failsafe()
         keyboard.add_hotkey(self.hotkey_var.get(), self.trigger_search)
         self.protocol('WM_DELETE_WINDOW', self.on_close)
 
@@ -357,6 +360,9 @@ class App(tk.Tk):
         keyboard.clear_all_hotkeys()
         keyboard.add_hotkey(self.hotkey_var.get(), self.trigger_search)
 
+    def update_failsafe(self, *_):
+        pyautogui.FAILSAFE = self.failsafe_var.get()
+
     def show_about(self):
         messagebox.showinfo('About', 'KeyleFinder\nAuthor: keyle\nhttps://vrast.cn')
 
@@ -366,6 +372,7 @@ class App(tk.Tk):
         win.resizable(False, False)
         ttk.Checkbutton(win, text='Debug', variable=self.debug_var).pack(anchor='w', padx=10, pady=5)
         ttk.Checkbutton(win, text='Auto Start', variable=self.auto_start_var).pack(anchor='w', padx=10, pady=5)
+        ttk.Checkbutton(win, text='Fail-safe', variable=self.failsafe_var).pack(anchor='w', padx=10, pady=5)
         loop_chk = ttk.Checkbutton(win, text='循环执行 (危险)', variable=self.loop_var)
         loop_chk.pack(anchor='w', padx=10, pady=5)
         loop_chk.config(style='Danger.TCheckbutton')


### PR DESCRIPTION
## Summary
- allow turning pyautogui fail-safe on/off in GUI
- make CLI expose `--disable-failsafe`
- document the new option in README

## Testing
- `python KeyleFinderModuleTest.py`
- `python cli_workflow.py --help` *(fails: can't connect to display)*

------
https://chatgpt.com/codex/tasks/task_e_6841c14cda8083239e0d36fc67e30ea3