### PR TITLE
Fix long press logic

### DIFF
--- a/cli_workflow.py
+++ b/cli_workflow.py
@@ -66,9 +66,9 @@ def run_workflow(items, debug=False, loop=False, interval=0.5):
                     if pyautogui.position() != long_press_pos:
                         pyautogui.mouseUp()
                         long_press_active = False
-                    else:
-                        pyautogui.mouseUp()
-                        long_press_active = False
+                if long_press_active and item.get('action') != 'long':
+                    pyautogui.mouseUp()
+                    long_press_active = False
 
                 time.sleep(item.get('delay', 0) / 1000.0)
 

--- a/gui_locator_multi.py
+++ b/gui_locator_multi.py
@@ -481,6 +481,9 @@ class App(tk.Tk):
 
         def run_items(idx=0):
             if idx >= len(self.items):
+                if self.long_press_active:
+                    pyautogui.mouseUp()
+                    self.long_press_active = False
                 if self.loop_var.get():
                     self.after(500, lambda: run_items(0))
                 else:
@@ -492,7 +495,7 @@ class App(tk.Tk):
                 self.after(10, lambda: run_items(idx + 1))
                 return
 
-            if self.long_press_active:
+            if self.long_press_active and item.get('action') != 'long':
                 pyautogui.mouseUp()
                 self.long_press_active = False
 


### PR DESCRIPTION
## Summary
- ensure long press isn't immediately released in CLI workflow
- stop GUI from releasing long press before the next action
- release long press when workflow ends

## Testing
- `python KeyleFinderModuleTest.py | head`
- `python -m py_compile KeyleFinderModule.py KeyleFinderModuleTest.py cli_workflow.py gui_locator_multi.py`


------
https://chatgpt.com/codex/tasks/task_e_68425ead1c1c8323bd9be51a18103d1e