### PR TITLE
Fix long press timing

### DIFF
--- a/cli_workflow.py
+++ b/cli_workflow.py
@@ -66,11 +66,13 @@ def run_workflow(items, debug=False, loop=False, interval=0.5):
                     if pyautogui.position() != long_press_pos:
                         pyautogui.mouseUp()
                         long_press_active = False
+
+                delay = item.get('delay', 0) / 1000.0
+                time.sleep(delay)
+
                 if long_press_active and item.get('action') != 'long':
                     pyautogui.mouseUp()
                     long_press_active = False
-
-                time.sleep(item.get('delay', 0) / 1000.0)
 
                 screenshot = pyautogui.screenshot()
                 with tempfile.NamedTemporaryFile(delete=False, suffix='.png') as tmp:

--- a/gui_locator_multi.py
+++ b/gui_locator_multi.py
@@ -495,13 +495,13 @@ class App(tk.Tk):
                 self.after(10, lambda: run_items(idx + 1))
                 return
 
-            if self.long_press_active and item.get('action') != 'long':
-                pyautogui.mouseUp()
-                self.long_press_active = False
-
             delay = item.get('delay', 0)
 
             def execute():
+                if self.long_press_active and item.get('action') != 'long':
+                    pyautogui.mouseUp()
+                    self.long_press_active = False
+
                 item_id = self.tree.get_children()[idx]
                 self.tree.item(item_id, tags=('running',))
                 with tempfile.NamedTemporaryFile(delete=False, suffix='.png') as tmp:


### PR DESCRIPTION
## Summary
- ensure long press lasts through the next item delay
- release held mouse button when executing subsequent action

## Testing
- `python -m py_compile KeyleFinderModule.py cli_workflow.py gui_locator_multi.py KeyleFinderModuleTest.py`
- `python KeyleFinderModuleTest.py`

------
https://chatgpt.com/codex/tasks/task_e_684277f9ad548323bbca8a8526e55d2d