### PR TITLE
Adjust delay handling

### DIFF
--- a/cli_workflow.py
+++ b/cli_workflow.py
@@ -67,9 +67,6 @@ def run_workflow(items, debug=False, loop=False, interval=0.5):
                         pyautogui.mouseUp()
                         long_press_active = False
 
-                delay = item.get('delay', 0) / 1000.0
-                time.sleep(delay)
-
                 if long_press_active and item.get('action') != 'long':
                     pyautogui.mouseUp()
                     long_press_active = False
@@ -103,6 +100,8 @@ def run_workflow(items, debug=False, loop=False, interval=0.5):
                     else:
                         idx += 1
                 os.unlink(screen_path)
+                delay = item.get('delay', 0) / 1000.0
+                time.sleep(delay)
             if long_press_active:
                 pyautogui.mouseUp()
                 long_press_active = False

--- a/gui_locator_multi.py
+++ b/gui_locator_multi.py
@@ -495,8 +495,6 @@ class App(tk.Tk):
                 self.after(10, lambda: run_items(idx + 1))
                 return
 
-            delay = item.get('delay', 0)
-
             def execute():
                 if self.long_press_active and item.get('action') != 'long':
                     pyautogui.mouseUp()
@@ -511,6 +509,7 @@ class App(tk.Tk):
                     result = finder.locate(item['path'], debug=self.debug_var.get())
                 os.unlink(tmp.name)
 
+                next_idx = idx + 1
                 if result.get('status') == 0:
                     tl = result['top_left']
                     br = result['bottom_right']
@@ -535,16 +534,16 @@ class App(tk.Tk):
                         tags.remove('fail')
                     self.tree.item(item_id, tags=tuple(tags))
                     self.log(f'Item {idx} matched at {click_x},{click_y}')
-                    self.after(10, lambda: run_items(idx + 1))
                 else:
                     self.tree.item(item_id, tags=('fail',))
                     self.log(f'Item {idx} match failed')
                     if item.get('interrupt'):
-                        self.after(10, lambda: run_items(0))
-                    else:
-                        self.after(10, lambda: run_items(idx + 1))
+                        next_idx = 0
 
-            self.after(delay, execute)
+                delay = item.get('delay', 0)
+                self.after(delay, lambda: run_items(next_idx))
+
+            execute()
 
         self.tree.tag_configure('running', background='lightgreen')
         self.tree.tag_configure('fail', background='lightcoral')


### PR DESCRIPTION
## Summary
- trigger actions before waiting for delay in CLI workflow
- adjust GUI workflow to wait after each action rather than before

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68427af71c288323a42a8aff9a3eb492