### PR TITLE
Add cross-platform build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,96 @@
+name: Build Binaries
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build_windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install pyinstaller pyautogui pyscreeze pytweening mouseinfo
+      - name: Build EXE
+        run: |
+          pyinstaller --onefile --noconsole --name "GUI_Locator" `
+            --hidden-import pyautogui `
+            --hidden-import pyscreeze `
+            --hidden-import pytweening `
+            --hidden-import mouseinfo `
+            --collect-data pyautogui `
+            gui_locator_multi.py
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows
+          path: dist/GUI_Locator.exe
+
+  build_macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install pyinstaller pyautogui pyscreeze pytweening mouseinfo pyobjc-core pyobjc
+      - name: Build macOS binary
+        run: |
+          pyinstaller --onefile --name GUI_Locator gui_locator_multi.py
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos
+          path: dist/GUI_Locator
+
+  release:
+    needs: [build_windows, build_macos]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: windows
+          path: artifacts/windows
+      - name: Download macos artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macos
+          path: artifacts/macos
+      - name: Create release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: build-${{ github.run_number }}
+          name: Build ${{ github.run_number }}
+          prerelease: true
+          files: |
+            artifacts/windows/GUI_Locator.exe
+            artifacts/macos/GUI_Locator
+      - name: Update README with build links
+        run: |
+          WIN_URL="https://github.com/${{ github.repository }}/releases/download/${{ steps.create_release.outputs.tag_name }}/GUI_Locator.exe"
+          MAC_URL="https://github.com/${{ github.repository }}/releases/download/${{ steps.create_release.outputs.tag_name }}/GUI_Locator"
+          sed -i '/<!-- BUILD LINKS START -->/,/<!-- BUILD LINKS END -->/c\\\n<!-- BUILD LINKS START -->\n- [Windows]('"$WIN_URL"')\n- [macOS]('"$MAC_URL"')\n<!-- BUILD LINKS END -->' README.md
+      - name: Commit README update
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add README.md
+          git commit -m "Update build links" || echo "No changes"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -110,3 +110,9 @@ AutoClick 是一个自动点击工具，通过配置模板图像来实现开发�
 ### 免责声明
 
 本工具旨在加速自动化调试，请勿将其用于任何非法用途。
+
+## Latest Build
+
+<!-- BUILD LINKS START -->
+链接更新中...
+<!-- BUILD LINKS END -->


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Windows/macOS binaries
- append placeholders in README for auto-updated download links

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684290ac00b08323bf3026b1d6885415