### PR TITLE
Fix README build links and bundle OpenCV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,8 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          pip install pyinstaller pyautogui pyscreeze pytweening mouseinfo
+          pip install pyinstaller pyautogui pyscreeze pytweening mouseinfo \
+            opencv-python-headless numpy Pillow
       - name: Build EXE
         run: |
           pyinstaller --onefile --noconsole --name "GUI_Locator" `
@@ -27,6 +28,7 @@ jobs:
             --hidden-import pyscreeze `
             --hidden-import pytweening `
             --hidden-import mouseinfo `
+            --hidden-import cv2 `
             --collect-data pyautogui `
             gui_locator_multi.py
       - name: Upload artifact
@@ -45,10 +47,18 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          pip install pyinstaller pyautogui pyscreeze pytweening mouseinfo pyobjc-core pyobjc
+          pip install pyinstaller pyautogui pyscreeze pytweening mouseinfo \
+            pyobjc-core pyobjc opencv-python-headless numpy Pillow
       - name: Build macOS binary
         run: |
-          pyinstaller --onefile --name GUI_Locator gui_locator_multi.py
+          pyinstaller --onefile --name GUI_Locator \
+            --hidden-import pyautogui \
+            --hidden-import pyscreeze \
+            --hidden-import pytweening \
+            --hidden-import mouseinfo \
+            --hidden-import cv2 \
+            --collect-data pyautogui \
+            gui_locator_multi.py
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,6 @@ AutoClick 是一个自动点击工具，通过配置模板图像来实现开发�
 ## Latest Build
 
 \n<!-- BUILD LINKS START -->
-- [Windows](https://github.com/KeyleXiao/AutoClick/releases/download//GUI_Locator.exe)
-- [macOS](https://github.com/KeyleXiao/AutoClick/releases/download//GUI_Locator)
+- [Windows](https://github.com/KeyleXiao/AutoClick/releases/latest/download/GUI_Locator.exe)
+- [macOS](https://github.com/KeyleXiao/AutoClick/releases/latest/download/GUI_Locator)
 <!-- BUILD LINKS END -->


### PR DESCRIPTION
## Summary
- fix links to Windows and macOS builds in README
- install OpenCV and other deps during packaging
- bundle cv2 with PyInstaller build steps

## Testing
- `python KeyleFinderModuleTest.py` *(fails: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68429e2115a88323b3bdd65fe4a2b427